### PR TITLE
Get rid of `unarchived` directory

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -24,7 +24,7 @@ workflows:
             #!/bin/bash
 
             ARCHIVED_FILE_PATH=downloads/resource.zip
-            ARCHIVE_FILE_PATH=$EXTRACT_URL/unarchived/
+            ARCHIVE_FILE_PATH=$EXTRACT_URL/
             UNARCHIVED_FILE_PATH=unarchived/
 
             if [ -f "$ARCHIVED_FILE_PATH" ]; then

--- a/step.sh
+++ b/step.sh
@@ -53,7 +53,7 @@ if [ ! -d "$extract_to_path" ]; then
 fi;
 
 # --- Copy to the required location
-cp -r unarchived/ "$extract_to_path"
+cp -r unarchived/* "$extract_to_path"
 copy_result=$?
 if [ $copy_result -eq 0 ]; then
   echo " (i) Copy OK"

--- a/step.yml
+++ b/step.yml
@@ -1,7 +1,7 @@
 title: ZIP resource archive downloader
 summary: ZIP resource archive downloader
 description: |-
-  Downloads and extracts a .ZIP archive to a specified path. Please note that the step creates an `unarchived` folder at the specified location. You will find the contents of the .ZIP archive in the `unarchived` folder.
+  Downloads and extracts a .ZIP archive to a specified path. You will find the contents of the .ZIP archive in the folder you specifed with $extract_to_path.
 website: https://github.com/bitrise-io/steps-resource-archive
 source_code_url: https://github.com/bitrise-io/steps-resource-archive
 support_url: https://github.com/bitrise-io/steps-resource-archive/issues


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR* [version update](https://semver.org/)


### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

We currently start to use this step and found out that the content land in the directory `$extra_to_path/unarchived`.
We thought this is a strange behaviour to "create an additionally directoy within the "extract_to_path" input".
So I thought it make sense to simply remove this extra directoy. 🙃 

### Changes

* Copy only contents from the downloaded and extract `zip` archive to the `extract_to_path` input. Not the whole `unarchived` directoy.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
It is not so obvious by using this step, declaring the `extra_to_path` path but content wil land in `extra_to_path/unarchived`. Its more obvious that the content land directoy into `extra_to_path`.

